### PR TITLE
EntityHub: Unset parent id if parent is not fetched

### DIFF
--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -825,6 +825,8 @@ class EntityHub(object):
         parent = self._entities_by_id.get(parent_id)
         if parent is not None:
             parent.remove_child(entity.id)
+        else:
+            self.unset_entity_parent(entity.id, parent_id)
 
     def reset_immutable_for_hierarchy_cache(
         self, entity_id: Optional[str], bottom_to_top: Optional[bool] = True


### PR DESCRIPTION
## Changelog Description
Make sure that entity is marked as removed even if parent is not fetched.

## Testing notes:
1. Get e.g. product by id in entity hub.
2. Delete the product via entity hub
3. Commit changes on entity hub.
4. The product should be deleted in database.
