### PR TITLE
Products: Fix statuses and tags filtering

### DIFF
--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -278,8 +278,8 @@ def products_graphql_query(fields):
     product_types_var = query.add_variable("productTypes", "[String!]")
     product_name_regex_var = query.add_variable("productNameRegex", "String!")
     product_path_regex_var = query.add_variable("productPathRegex", "String!")
-    statuses_var = query.add_variable("productStatuses.", "[String!]")
-    tags_var = query.add_variable("productTags.", "[String!]")
+    statuses_var = query.add_variable("productStatuses", "[String!]")
+    tags_var = query.add_variable("productTags", "[String!]")
 
     project_field = query.add_field("project")
     project_field.set_filter("name", project_name_var)


### PR DESCRIPTION
## Changelog Description
Fix products filtering in products GraphQl query.

## Additional review information
There was trailing dot in statuses and tags variable names in product query leading to raise `KeyError` when the variables should be filled.

## Testing notes:
1. start with this step
2. follow this step

Resolves https://github.com/ynput/ayon-python-api/issues/257