### PR TITLE
Operations: Fix task id handling in update version

### DIFF
--- a/ayon_api/operations.py
+++ b/ayon_api/operations.py
@@ -1320,7 +1320,6 @@ class OperationsSession(object):
         for key, value in (
             ("version", version),
             ("productId", product_id),
-            ("taskId", task_id),
             ("attrib", attrib),
             ("data", data),
             ("tags", tags),


### PR DESCRIPTION
## Changelog Description
Handle 'taskId' argument correctly.

## Additional review information
Calling `operations.update_version` should not require to pass in task id to update anything else on version.

## Testing notes:
1. Call `update_version` updating e.g. data or attributes only.
