### PR TITLE
GraphQl: Fix used type to create edge field

### DIFF
--- a/ayon_api/graphql.py
+++ b/ayon_api/graphql.py
@@ -857,8 +857,8 @@ class GraphQlQueryEdgeField(BaseGraphQlQueryField):
         self._edge_children.append(field)
         field.set_parent(self)
 
-    def add_edge_field(self, name: str) -> GraphQlQueryEdgeField:
-        item = GraphQlQueryEdgeField(name, self, self._order)
+    def add_edge_field(self, name: str) -> GraphQlQueryField:
+        item = GraphQlQueryField(name, self, self._order)
         self.add_obj_edge_field(item)
         return item
 


### PR DESCRIPTION
## Changelog Description
Use correct type for field to use.

## Additional review information
Not sure when this changed but it was using wrong field type for subfields in edges.

## Testing notes:
1. Get link functions do work.
