### PR TITLE
List entity: Fetch items in GraphQl

### DIFF
--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -252,4 +252,8 @@ DEFAULT_ENTITY_LIST_FIELDS = {
     "tags",
     "updatedAt",
     "updatedBy",
+    "items.id",
+    "items.entityId",
+    "items.entityType",
+    "items.position",
 }

--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -680,9 +680,25 @@ def entity_lists_graphql_query(fields):
     entity_lists_field = project_field.add_field_with_edges("entityLists")
     entity_lists_field.set_filter("ids", entity_list_ids)
 
-    nested_fields = fields_to_dict(set(fields))
+    fields = set(fields)
+    items_field_names = set()
+    for field_name in set(fields):
+        field_name.removeprefix("items")
+        if not field_name.startswith("items"):
+            continue
+
+        fields.discard(field_name)
+        field_name = field_name.removeprefix("items").lstrip(".")
+        if field_name:
+            items_field_names.add(field_name)
 
     query_queue = collections.deque()
+    if items_field_names:
+        items_field = entity_lists_field.add_field_with_edges("items")
+        for field_name in items_field_names:
+            items_field.add_edge_field(field_name)
+
+    nested_fields = fields_to_dict(set(fields))
     for key, value in nested_fields.items():
         query_queue.append((key, value, entity_lists_field))
 


### PR DESCRIPTION
## Changelog Description
Fetch items on list entities.

## Additional review information
Allow to receive items with position from an entity list.

## Testing notes:
1. Using `get_entity_lists` returns list entities with items.
