### PR TITLE
Project: Add product type fields to graphql fields

### DIFF
--- a/ayon_api/_api_helpers/projects.py
+++ b/ayon_api/_api_helpers/projects.py
@@ -684,7 +684,7 @@ class ProjectsAPI(BaseServerAPI):
                 must_use_graphql = True
                 fields.discard(field)
                 for f_name in DEFAULT_PRODUCT_TYPE_FIELDS:
-                    fields.add(f"{field}.{f_name}")
+                    graphql_fields.add(f"{field}.{f_name}")
 
             elif field.startswith("productTypes"):
                 must_use_graphql = True
@@ -694,7 +694,7 @@ class ProjectsAPI(BaseServerAPI):
                 must_use_graphql = True
                 fields.discard(field)
                 for f_name in DEFAULT_PRODUCT_BASE_TYPE_FIELDS:
-                    fields.add(f"{field}.{f_name}")
+                    graphql_fields.add(f"{field}.{f_name}")
 
             elif field.startswith("productBaseTypes"):
                 must_use_graphql = True


### PR DESCRIPTION
## Changelog Description
Fix product type and product base types fetching on a project.

## Additional review information
The fields to fetch were added to wrong set. Instead of 

## Testing notes:
1. Using `get_project("projectname", fields={"productTypes"})` does actually return product types from graphql.
