### PR TITLE
Transfer: Add retry options to upload and download

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1589,6 +1589,7 @@ class ServerAPI(
                 if attempt == retries:
                     raise
                 progress.next_attempt()
+                progress.reset_transferred()
 
         response.raise_for_status()
         return response

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -862,7 +862,6 @@ class TransferProgress:
         if not self._started:
             raise ValueError("Progress did not start yet")
         self._attempt += 1
-        self._transferred = 0
 
     def get_transfer_done(self) -> bool:
         """Transfer finished.
@@ -933,6 +932,10 @@ class TransferProgress:
 
         """
         self._transferred = transferred
+
+    def reset_transferred(self) -> None:
+        """Reset transferred size to initial value."""
+        self._transferred = 0
 
     def add_transferred_chunk(self, chunk_size: int):
         """Add transferred chunk size in bytes.


### PR DESCRIPTION
## Changelog Description
Upload and download use retries if connection fails.

## Additional review information
Added attempt to TransferProgress to track how many times it tried. Download can continue where ended up. Fixed `_endpoint_to_url` to use base url instead of graphql endpoint and download/upload functions do request endpoint without `/api`.

## Testing notes:
1. Upload and download can be retried (don't ask me how to test that please).
2. Validate code changes.

Resolves https://github.com/ynput/ayon-python-api/issues/291