### PR TITLE
EntityData: Better deepcopy and error handling

### DIFF
--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1469,7 +1469,7 @@ class EntityData(dict):
             except RecursionError:
                 raise RuntimeError(
                     f"Failed to create copy of key '{key}'"
-                    " because of recursion!!!"
+                    " because of recursion."
                 )
 
             try:
@@ -1477,7 +1477,7 @@ class EntityData(dict):
             except RecursionError:
                 raise RuntimeError(
                     f"Failed to create copy of value '{key}'"
-                    " because of recursion!!!"
+                    " because of recursion."
                 )
 
         self._orig_data = orig_data


### PR DESCRIPTION
## Changelog Description
Use deepcopy of key and value instead of full object in `EntityData`.

## Additional review information
This might help to prevent recursion error, and if not then the error might help to reveal what the issue is.

## Testing notes:
1. Use the code in shotgrid sync services.

Should help to resolve https://github.com/ynput/ayon-python-api/issues/288