### PR TITLE
Upload: Fix headers handling

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -1276,7 +1276,6 @@ def upload_reviewable(
     content_type: Optional[str] = None,
     filename: Optional[str] = None,
     progress: Optional[TransferProgress] = None,
-    headers: Optional[dict[str, Any]] = None,
     **kwargs,
 ) -> requests.Response:
     """Upload reviewable file to server.
@@ -1291,7 +1290,6 @@ def upload_reviewable(
         filename (Optional[str]): User as original filename. Filename from
             'filepath' is used when not filled.
         progress (Optional[TransferProgress]): Progress.
-        headers (Optional[dict[str, Any]]): Headers.
 
     Returns:
         requests.Response: Server response.
@@ -1306,7 +1304,6 @@ def upload_reviewable(
         content_type=content_type,
         filename=filename,
         progress=progress,
-        headers=headers,
         **kwargs,
     )
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1985,7 +1985,6 @@ class ServerAPI(
         content_type: Optional[str] = None,
         filename: Optional[str] = None,
         progress: Optional[TransferProgress] = None,
-        headers: Optional[dict[str, Any]] = None,
         **kwargs
     ) -> requests.Response:
         """Upload reviewable file to server.
@@ -2000,7 +1999,6 @@ class ServerAPI(
             filename (Optional[str]): User as original filename. Filename from
                 'filepath' is used when not filled.
             progress (Optional[TransferProgress]): Progress.
-            headers (Optional[dict[str, Any]]): Headers.
 
         Returns:
             requests.Response: Server response.
@@ -2029,7 +2027,6 @@ class ServerAPI(
             progress=progress,
             content_type=content_type,
             filename=filename,
-            headers=headers,
             request_type=RequestTypes.post,
             **kwargs
         )

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1792,7 +1792,10 @@ class ServerAPI(
         url = self._endpoint_to_url(endpoint, use_rest=False)
         progress.set_destination_url(url)
 
-        headers = kwargs.setdefault("headers", {})
+        headers = kwargs.get("headers")
+        if headers is None:
+            kwargs["headers"] = headers = {}
+
         headers_keys_by_low_key = {key.lower(): key for key in headers}
         if self._session is None:
             for key, value in self.get_headers().items():


### PR DESCRIPTION
## Changelog Description
Fix headers being `None`.

## Additional review information
Upload reviewable has defined `headers` kwarg which is set to `None` which is not expected to be in `_upload_file`.

## Testing notes:
1. Calling `upload_reviewable` without `headers` kwarg should work.
