### PR TITLE
Download: Autofix download api prefix

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1408,7 +1408,10 @@ class ServerAPI(
             try:
                 with get_func(url, **kwargs) as response:
                     # Auto-fix missing 'api/'
-                    if response.status_code == 404 and not api_prepended:
+                    if (
+                        response.status_code in (404, 405)
+                        and not api_prepended
+                    ):
                         api_prepended = True
                         if (
                             not endpoint.startswith(self._base_url)
@@ -1841,7 +1844,7 @@ class ServerAPI(
                     **kwargs
                 )
                 # Auto-fix missing 'api/'
-                if response.status_code == 405 and not api_prepended:
+                if response.status_code in (404, 405) and not api_prepended:
                     api_prepended = True
                     if (
                         not endpoint.startswith(self._base_url)

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1838,7 +1838,7 @@ class ServerAPI(
                     **kwargs
                 )
                 # Auto-fix missing 'api/'
-                if response.status_code == 405 and not api_prepended:
+                if response.status_code in (404, 405) and not api_prepended:
                     api_prepended = True
                     if (
                         not endpoint.startswith(self._base_url)

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1408,7 +1408,7 @@ class ServerAPI(
             try:
                 with get_func(url, **kwargs) as response:
                     # Auto-fix missing 'api/'
-                    if response.status_code == 405 and not api_prepended:
+                    if response.status_code == 404 and not api_prepended:
                         api_prepended = True
                         if (
                             not endpoint.startswith(self._base_url)
@@ -1838,7 +1838,7 @@ class ServerAPI(
                     **kwargs
                 )
                 # Auto-fix missing 'api/'
-                if response.status_code in (404, 405) and not api_prepended:
+                if response.status_code in 405 and not api_prepended:
                     api_prepended = True
                     if (
                         not endpoint.startswith(self._base_url)

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1838,7 +1838,7 @@ class ServerAPI(
                     **kwargs
                 )
                 # Auto-fix missing 'api/'
-                if response.status_code in 405 and not api_prepended:
+                if response.status_code == 405 and not api_prepended:
                     api_prepended = True
                     if (
                         not endpoint.startswith(self._base_url)


### PR DESCRIPTION
## Changelog Description
Autofix api prefix for download too.

## Additional review information
Wrong endpoint for upload returns `405` but for download it is `404`.

## Testing notes:
1. Use `download_file` to download file which is under `api/...` endpoint but pass then endpoint without `api/` prefix. (e.g. `addons/applications/1.3.3+dev/icons/nuke.png`).
2. It should download the file.