### PR TITLE
Projects: Fix library filtering for GraphQl

### DIFF
--- a/ayon_api/_api_helpers/projects.py
+++ b/ayon_api/_api_helpers/projects.py
@@ -810,6 +810,10 @@ class ProjectsAPI(BaseServerAPI):
             for project in parsed_data["projects"]:
                 if active is not None and active is not project["active"]:
                     continue
+
+                if library is not None and library is not project["library"]:
+                    continue
+
                 if own_attributes:
                     fill_own_attribs(project)
                 self._fill_project_entity_data(project)


### PR DESCRIPTION
## Changelog Description
Library filtering is working when graphql is being used.

## Additional review information
Library filtering was completelly ignored.

## Testing notes:
1. Try to fetch only library projects.
2. It should return only library projects.
