### PR TITLE
Projects: Own attrib with GraphQl

### DIFF
--- a/ayon_api/_api_helpers/projects.py
+++ b/ayon_api/_api_helpers/projects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import platform
 import warnings
@@ -810,8 +811,21 @@ class ProjectsAPI(BaseServerAPI):
             for project in parsed_data["projects"]:
                 if active is not None and active is not project["active"]:
                     continue
-                if own_attributes:
-                    fill_own_attribs(project)
+
+                all_attrib = project.get("allAttrib")
+                if isinstance(all_attrib, str):
+                    all_attrib = json.loads(all_attrib)
+                    project["allAttrib"] = all_attrib
+
+                if own_attributes and all_attrib:
+                    own_attrib = {}
+                    if all_attrib:
+                        own_attrib = copy.deepcopy(all_attrib)
+                    attrib = project.get("attrib", {})
+                    for key in attrib.keys():
+                        own_attrib.setdefault(key, None)
+                    project["ownAttrib"] = own_attrib
+
                 self._fill_project_entity_data(project)
                 yield project
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2425,8 +2425,11 @@ class ServerAPI(
             fields.remove("attrib")
             fields |= self.get_attributes_fields_for_type(entity_type)
 
-        if own_attributes and entity_type in {"project", "folder", "task"}:
-            fields.add("ownAttrib")
+        if own_attributes:
+            if entity_type == "project":
+                fields.add("allAttrib")
+            elif entity_type in {"folder", "task"}:
+                fields.add("ownAttrib")
 
         if entity_type != "project":
             return


### PR DESCRIPTION
## Changelog Description
Fix ownAttrib for project entity.

## Additional review information
Project node in GraphQl does not have `ownAttrib` but has `allAttrib` which can be used instead.

## Testing notes:
1. Call `ayon_api.get_project("yourproject", own_attributes=True)`.
2. It should not crash and the project should have `ownAttrib` with the attribute values only explicitly set on a project.
