### PR TITLE
Add missing entity id argument to `create_entity_list_item`

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -7710,6 +7710,7 @@ def set_entity_list_attribute_definitions(
 def create_entity_list_item(
     project_name: str,
     list_id: str,
+    entity_id: str,
     *,
     position: Optional[int] = None,
     label: Optional[str] = None,
@@ -7723,6 +7724,7 @@ def create_entity_list_item(
     Args:
         project_name (str): Project name where entity list lives.
         list_id (str): Entity list id where item will be added.
+        entity_id (str): Id of entity added to the list.
         position (Optional[int]): Position of item in entity list.
         label (Optional[str]): Label of item in entity list.
         attrib (Optional[dict[str, Any]]): Item attribute values.
@@ -7738,6 +7740,7 @@ def create_entity_list_item(
     return con.create_entity_list_item(
         project_name=project_name,
         list_id=list_id,
+        entity_id=entity_id,
         position=position,
         label=label,
         attrib=attrib,

--- a/ayon_api/_api_helpers/lists.py
+++ b/ayon_api/_api_helpers/lists.py
@@ -342,9 +342,11 @@ class ListsAPI(BaseServerAPI):
         """
         if item_id is None:
             item_id = create_entity_id()
+
+        data = data or {}
         kwargs = {
             "id": item_id,
-            "entityId": list_id,
+            "entityId": data.pop("entityId"),
         }
         for key, value in (
             ("position", position),

--- a/ayon_api/_api_helpers/lists.py
+++ b/ayon_api/_api_helpers/lists.py
@@ -316,6 +316,7 @@ class ListsAPI(BaseServerAPI):
         self,
         project_name: str,
         list_id: str,
+        entity_id: str,
         *,
         position: Optional[int] = None,
         label: Optional[str] = None,
@@ -329,6 +330,7 @@ class ListsAPI(BaseServerAPI):
         Args:
             project_name (str): Project name where entity list lives.
             list_id (str): Entity list id where item will be added.
+            entity_id (str): Id of entity added to the list.
             position (Optional[int]): Position of item in entity list.
             label (Optional[str]): Label of item in entity list.
             attrib (Optional[dict[str, Any]]): Item attribute values.
@@ -343,10 +345,9 @@ class ListsAPI(BaseServerAPI):
         if item_id is None:
             item_id = create_entity_id()
 
-        data = data or {}
         kwargs = {
             "id": item_id,
-            "entityId": data.pop("entityId"),
+            "entityId": entity_id,
         }
         for key, value in (
             ("position", position),


### PR DESCRIPTION
## Changelog Description
Add missing entity id argument to `create_entity_list_item` function.

### Issue
I cannot have `create_entity_list_item` working. Somehow it feels like it misses some slot for the `entityId` can be provided.

```
WARNING:RestApiResponse:HTTP request error: 404 Client Error: Not Found for url: http://192.168.0.118:5000/api/projects/Dummy/lists/4d55701c36e311f180d18ae1d06b982f/items
2026-04-15 13:44:37:  0: STDOUT: {
2026-04-15 13:44:37:  0: STDOUT:     "code": 404,
2026-04-15 13:44:37:  0: STDOUT:     "detail": "Version 4d55701c36e311f180d18ae1d06b982f not found"
2026-04-15 13:44:37:  0: STDOUT: }
```

## Testing notes:
1. Call `create_entity_list_item` providing a `entityId`
2. Ensure a new item with the entity get created in your list
