### PR TITLE
Benevolent validate url

### DIFF
--- a/ayon_api/exceptions.py
+++ b/ayon_api/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 
 try:
@@ -21,13 +23,23 @@ class UrlError(Exception):
     UI if needed.
     """
 
-    def __init__(self, message, title, hints=None):
+
+    def __init__(
+        self,
+        message: str,
+        title: str,
+        hints: list[str] | None = None,
+    ) -> None:
         if hints is None:
             hints = []
 
         self.title = title
         self.hints = hints
-        super(UrlError, self).__init__(message)
+        super().__init__(message)
+
+
+class UrlNotReached(UrlError):
+    pass
 
 
 class ServerError(Exception):

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -798,14 +798,9 @@ def validate_url(
         return new_url
 
     hints = []
-    if "/" in parsed_url.path or not parsed_url.scheme:
-        new_path = parsed_url.path.split("/")[0]
-        if not parsed_url.scheme:
-            new_path = "https://" + new_path
-
-        hints.append(
-            "did you mean \"{}\"?".format(parsed_url.scheme + new_path)
-        )
+    if parsed_url.path:
+        new_path = f"{parsed_url.scheme}{parsed_url.netloc}"
+        hints.append(f"did you mean \"{new_path}\"?")
 
     raise UrlError(
         "Couldn't connect to server on \"{}\"".format(url),

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -570,11 +570,12 @@ def _try_connect_to_server(
         # TODO add validation if the url lead to AYON server
         #   - this won't validate if the url lead to 'google.com'
         response = requests.get(
-            url,
+            f"{url}/api/info",
             timeout=timeout,
             verify=verify,
             cert=cert,
         )
+        _ = response.json()
         if response.history:
             return response.history[-1].headers["location"].rstrip("/")
         return url
@@ -770,8 +771,9 @@ def validate_url(
     ]
     if parsed_url is None:
         raise UrlError(
-            "Invalid url format. Url cannot be parsed as url \"{}\".".format(
-                modified_url
+            (
+                "Invalid url format. Url cannot be parsed"
+                f" as url \"{modified_url}\"."
             ),
             title="Invalid url format",
             hints=universal_hints

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -777,11 +777,10 @@ def validate_url(
             hints=universal_hints
         )
 
-    # Try add 'https://' scheme if is missing
-    # - this will trigger UrlError if both will crash
-    if not parsed_url.scheme:
+    if parsed_url.path:
+        tmp_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
         new_url = _try_connect_to_server(
-            "http://" + modified_url,
+            tmp_url,
             timeout=timeout,
             verify=verify,
             cert=cert,

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -759,6 +759,11 @@ def validate_url(
 
     # Not sure if this is good idea?
     modified_url = stripperd_url.rstrip("/")
+
+    # Make sure url has http schema
+    if not modified_url.lower().startswith("http"):
+        modified_url = f"http://{modified_url}"
+
     parsed_url = _try_parse_url(modified_url)
     universal_hints = [
         "does the url work in browser?"

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -779,10 +779,9 @@ def validate_url(
             hints=universal_hints
         )
 
+    pathless_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
     if parsed_url.path:
-        tmp_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
         new_url = _try_connect_to_server(
-            tmp_url,
             timeout=timeout,
             verify=verify,
             cert=cert,
@@ -801,8 +800,7 @@ def validate_url(
 
     hints = []
     if parsed_url.path:
-        new_path = f"{parsed_url.scheme}{parsed_url.netloc}"
-        hints.append(f"did you mean \"{new_path}\"?")
+        hints.append(f"did you mean \"{pathless_url}\"?")
 
     raise UrlError(
         "Couldn't connect to server on \"{}\"".format(url),

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -27,6 +27,7 @@ from .constants import (
 )
 from .exceptions import (
     UrlError,
+    UrlNotReached,
     ServerError,
     UnauthorizedError,
     HTTPRequestError,
@@ -782,6 +783,7 @@ def validate_url(
     pathless_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
     if parsed_url.path:
         new_url = _try_connect_to_server(
+            pathless_url,
             timeout=timeout,
             verify=verify,
             cert=cert,
@@ -802,8 +804,8 @@ def validate_url(
     if parsed_url.path:
         hints.append(f"did you mean \"{pathless_url}\"?")
 
-    raise UrlError(
-        "Couldn't connect to server on \"{}\"".format(url),
+    raise UrlNotReached(
+        f"Couldn't connect to server on \"{url}\"",
         title="Couldn't connect to server",
         hints=hints + universal_hints
     )

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -761,7 +761,7 @@ def validate_url(
     # Not sure if this is good idea?
     modified_url = stripperd_url.rstrip("/")
 
-    # Make sure url has http schema
+    # Make sure url has http scheme
     if not modified_url.lower().startswith("http"):
         modified_url = f"http://{modified_url}"
 

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -751,8 +751,8 @@ def validate_url(
         UrlError: Error with short description and hints for user.
 
     """
-    stripperd_url = url.strip()
-    if not stripperd_url:
+    stripped_url = url.strip()
+    if not stripped_url:
         raise UrlError(
             "Invalid url format. Url is empty.",
             title="Invalid url format",
@@ -760,7 +760,7 @@ def validate_url(
         )
 
     # Not sure if this is good idea?
-    modified_url = stripperd_url.rstrip("/")
+    modified_url = stripped_url.rstrip("/")
 
     # Make sure url has http scheme
     if not modified_url.lower().startswith("http"):


### PR DESCRIPTION
## Changelog Description
Validate url function is more benevolent and allows url with path.

## Additional review information
Validate url allows to pass in nested url with path e.g. `dev.ayon.app/login` would be resolved as `http://dev.ayon.app`. Also fixes issue if localhost url is used without scheme `localhost:5000` is resolved as `http://localhost:5000`, the issue was that `localhost` was resolved as scheme because of `:` in the url.

This function is used in ayon launcher for login window.

## Testing notes:
1. Use the function with different options of AYON server url to find out if they are resolved correctly.

This is requirement for https://github.com/ynput/ayon-launcher/issues/208 .
