### PR TITLE
Fix nested edges pagination

### DIFF
--- a/ayon_api/graphql.py
+++ b/ayon_api/graphql.py
@@ -959,6 +959,12 @@ class GraphQlQueryEdgeField(BaseGraphQlQueryField):
             if total > self._limit:
                 limit_amount = self._limit - self._fetched_counter
 
+        if self.child_has_edges:
+            # Nested edge fields share a single cursor argument in the query.
+            # Query one parent item at a time so child pagination can't be
+            # overwritten by another parent from the same outer page.
+            limit_amount = min(limit_amount, 1)
+
         filters[limit_key] = limit_amount
 
         if self._cursor:

--- a/ayon_api/graphql.py
+++ b/ayon_api/graphql.py
@@ -963,7 +963,7 @@ class GraphQlQueryEdgeField(BaseGraphQlQueryField):
             # Nested edge fields share a single cursor argument in the query.
             # Query one parent item at a time so child pagination can't be
             # overwritten by another parent from the same outer page.
-            limit_amount = min(limit_amount, 1)
+            limit_amount = 1
 
         filters[limit_key] = limit_amount
 

--- a/tests/test_graphql_queries.py
+++ b/tests/test_graphql_queries.py
@@ -1,9 +1,12 @@
+from types import SimpleNamespace
+
 import pytest
 
 from ayon_api.graphql import GraphQlQuery
 from ayon_api.graphql_queries import (
     project_graphql_query,
     folders_graphql_query,
+    versions_graphql_query,
 )
 
 from .conftest import project_name_fixture
@@ -94,6 +97,120 @@ def test_get_variables_values(keys, values, types):
 
     expected = make_expected_get_variables_values(keys, values)
     assert query.get_variables_values() == expected
+
+
+class DummyConnection:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def query_graphql(self, query_str, variables):
+        self.calls.append((query_str, dict(variables)))
+        response = self._responses.pop(0)
+        return SimpleNamespace(errors=None, data={"data": response})
+
+
+def _version_link_edges(count, prefix):
+    return [
+        {"id": f"{prefix}-{idx}"}
+        for idx in range(count)
+    ]
+
+
+def test_nested_edge_pagination_queries_one_parent_at_a_time():
+    query = versions_graphql_query({"id", "links.id"})
+    query.set_variable_value("projectName", "test_project")
+
+    con = DummyConnection([
+        {
+            "project": {
+                "versions": {
+                    "edges": [{
+                        "cursor": "version-1",
+                        "node": {
+                            "id": "version-1",
+                            "links": {
+                                "edges": _version_link_edges(300, "link-a"),
+                                "pageInfo": {
+                                    "endCursor": "link-page-1",
+                                    "hasNextPage": True,
+                                }
+                            }
+                        }
+                    }],
+                    "pageInfo": {
+                        "endCursor": "versions-page-1",
+                        "hasNextPage": True,
+                    }
+                }
+            }
+        },
+        {
+            "project": {
+                "versions": {
+                    "edges": [{
+                        "cursor": "version-1",
+                        "node": {
+                            "id": "version-1",
+                            "links": {
+                                "edges": _version_link_edges(1, "link-b"),
+                                "pageInfo": {
+                                    "endCursor": "link-page-2",
+                                    "hasNextPage": False,
+                                }
+                            }
+                        }
+                    }],
+                    "pageInfo": {
+                        "endCursor": "versions-page-1",
+                        "hasNextPage": True,
+                    }
+                }
+            }
+        },
+        {
+            "project": {
+                "versions": {
+                    "edges": [{
+                        "cursor": "version-2",
+                        "node": {
+                            "id": "version-2",
+                            "links": {
+                                "edges": _version_link_edges(1, "link-c"),
+                                "pageInfo": {
+                                    "endCursor": "link-page-3",
+                                    "hasNextPage": False,
+                                }
+                            }
+                        }
+                    }],
+                    "pageInfo": {
+                        "endCursor": "versions-page-2",
+                        "hasNextPage": False,
+                    }
+                }
+            }
+        }
+    ])
+
+    output = query.query(con)
+
+    versions = output["project"]["versions"]
+    assert len(versions) == 2
+    assert versions[0]["id"] == "version-1"
+    assert len(versions[0]["links"]) == 301
+    assert versions[0]["links"][0]["id"] == "link-a-0"
+    assert versions[0]["links"][-1]["id"] == "link-b-0"
+    assert versions[1]["id"] == "version-2"
+    assert versions[1]["links"] == [{"id": "link-c-0"}]
+
+    first_query, second_query, third_query = [
+        query_str for query_str, _variables in con.calls
+    ]
+    assert "versions(first: 1)" in first_query
+    assert 'links(first: 300)' in first_query
+    assert 'links(first: 300, after: "link-page-1")' in second_query
+    assert 'versions(first: 1, after: "versions-page-1")' in third_query
 
 
 """

--- a/tests/test_graphql_queries.py
+++ b/tests/test_graphql_queries.py
@@ -1,12 +1,9 @@
-from types import SimpleNamespace
-
 import pytest
 
 from ayon_api.graphql import GraphQlQuery
 from ayon_api.graphql_queries import (
     project_graphql_query,
     folders_graphql_query,
-    versions_graphql_query,
 )
 
 from .conftest import project_name_fixture
@@ -97,120 +94,6 @@ def test_get_variables_values(keys, values, types):
 
     expected = make_expected_get_variables_values(keys, values)
     assert query.get_variables_values() == expected
-
-
-class DummyConnection:
-    def __init__(self, responses):
-        self._responses = list(responses)
-        self.calls = []
-
-    def query_graphql(self, query_str, variables):
-        self.calls.append((query_str, dict(variables)))
-        response = self._responses.pop(0)
-        return SimpleNamespace(errors=None, data={"data": response})
-
-
-def _version_link_edges(count, prefix):
-    return [
-        {"id": f"{prefix}-{idx}"}
-        for idx in range(count)
-    ]
-
-
-def test_nested_edge_pagination_queries_one_parent_at_a_time():
-    query = versions_graphql_query({"id", "links.id"})
-    query.set_variable_value("projectName", "test_project")
-
-    con = DummyConnection([
-        {
-            "project": {
-                "versions": {
-                    "edges": [{
-                        "cursor": "version-1",
-                        "node": {
-                            "id": "version-1",
-                            "links": {
-                                "edges": _version_link_edges(300, "link-a"),
-                                "pageInfo": {
-                                    "endCursor": "link-page-1",
-                                    "hasNextPage": True,
-                                }
-                            }
-                        }
-                    }],
-                    "pageInfo": {
-                        "endCursor": "versions-page-1",
-                        "hasNextPage": True,
-                    }
-                }
-            }
-        },
-        {
-            "project": {
-                "versions": {
-                    "edges": [{
-                        "cursor": "version-1",
-                        "node": {
-                            "id": "version-1",
-                            "links": {
-                                "edges": _version_link_edges(1, "link-b"),
-                                "pageInfo": {
-                                    "endCursor": "link-page-2",
-                                    "hasNextPage": False,
-                                }
-                            }
-                        }
-                    }],
-                    "pageInfo": {
-                        "endCursor": "versions-page-1",
-                        "hasNextPage": True,
-                    }
-                }
-            }
-        },
-        {
-            "project": {
-                "versions": {
-                    "edges": [{
-                        "cursor": "version-2",
-                        "node": {
-                            "id": "version-2",
-                            "links": {
-                                "edges": _version_link_edges(1, "link-c"),
-                                "pageInfo": {
-                                    "endCursor": "link-page-3",
-                                    "hasNextPage": False,
-                                }
-                            }
-                        }
-                    }],
-                    "pageInfo": {
-                        "endCursor": "versions-page-2",
-                        "hasNextPage": False,
-                    }
-                }
-            }
-        }
-    ])
-
-    output = query.query(con)
-
-    versions = output["project"]["versions"]
-    assert len(versions) == 2
-    assert versions[0]["id"] == "version-1"
-    assert len(versions[0]["links"]) == 301
-    assert versions[0]["links"][0]["id"] == "link-a-0"
-    assert versions[0]["links"][-1]["id"] == "link-b-0"
-    assert versions[1]["id"] == "version-2"
-    assert versions[1]["links"] == [{"id": "link-c-0"}]
-
-    first_query, second_query, third_query = [
-        query_str for query_str, _variables in con.calls
-    ]
-    assert "versions(first: 1)" in first_query
-    assert 'links(first: 300)' in first_query
-    assert 'links(first: 300, after: "link-page-1")' in second_query
-    assert 'versions(first: 1, after: "versions-page-1")' in third_query
 
 
 """


### PR DESCRIPTION
## Changelog Description

Fix truncation over 300 for `get_entities_links`

## Additional review information

This isn't the optimal fix - but it's the simplest one.

- if an edge has nested paginated children
- the outer edge page size becomes 1
- so each request contains exactly one parent node
- therefore the shared child cursor can only belong to that one parent

So instead of this broken shape:

1. fetch parents A, B, C in one outer page
2. parse A.links
3. parse B.links
4. parse C.links
5. shared `links._cursor` / `links._need_query` gets overwritten while processing that mixed batch

it becomes:

1. fetch parent A only
2. finish all pagination for A.links
3. advance outer cursor to parent B
4. finish all pagination for B.links
5. advance to C
6. and so on

This means that as pagination gets involved, it'll also paginate each 'parent' entity id one by one to avoid the bug essentially.
The only other means would be to actually keep track of the cursor state of each parent when nested pagination is involved. That would need to:

- keeps pagination state per parent instance
- records which specific parent items still have pending child pages
- issues a targeted follow-up query for that parent only
- then resumes the outer connection cursor normally

It adds a lot of complexity for not having to do ALL parents one by one, but only the select few you know require pagination.

This workaround: everything becomes one-parent-at-a-time immediately
Proper fix: first query can still fetch up to 300 parents at once, and only the parents with unfinished nested pagination get replayed individually afterward 

## Testing notes:

1. Truncation should not happen in the mixed 300+ with lower counts with multiple parents.
