### PR TITLE
Faster tasks by folder path fetching

### DIFF
--- a/ayon_api/_api_helpers/tasks.py
+++ b/ayon_api/_api_helpers/tasks.py
@@ -236,29 +236,21 @@ class TasksAPI(BaseServerAPI):
                 folder path.
 
         """
-        folder_paths = set(folder_paths)
-        if not project_name or not folder_paths:
-            return {}
-
-        graphql_filters = {
-            "projectName": project_name,
-            "folderPaths": list(folder_paths),
+        output = {
+            folder_path: []
+            for folder_path in folder_paths
         }
+        if not project_name or not output:
+            return output
 
-        if not prepare_list_filters(
-            graphql_filters,
-            ("taskNames", task_names),
-            ("taskTypes", task_types),
-            ("taskAssigneesAny", assignees),
-            ("taskAssigneesAll", assignees_all),
-            ("taskStatuses", statuses),
-            ("taskTags", tags),
-        ):
-            return {}
-
-        filters = self._prepare_advanced_filters(filters)
-        if filters:
-            graphql_filters["filter"] = filters
+        folder_path_by_id = {
+            folder["id"]: folder["path"]
+            for folder in self.get_folders(
+                project_name,
+                folder_paths=output.keys(),
+                fields={"id", "path"},
+            )
+        }
 
         if not fields:
             fields = self.get_default_fields_for_type("task")
@@ -266,31 +258,25 @@ class TasksAPI(BaseServerAPI):
             fields = set(fields)
             self._prepare_fields("task", fields, own_attributes)
 
-        if active is not None:
-            fields.add("active")
+        fields.add("folderId")
 
-        self._prepare_link_fields(fields)
+        for task_entity in self.get_tasks(
+            project_name,
+            folder_ids=folder_path_by_id.keys(),
+            task_names=task_names,
+            task_types=task_types,
+            assignees=assignees,
+            assignees_all=assignees_all,
+            statuses=statuses,
+            tags=tags,
+            active=active,
+            filters=filters,
+            fields=fields,
+        ):
+            folder_id = task_entity["folderId"]
+            folder_path = folder_path_by_id[folder_id]
+            output[folder_path].append(task_entity)
 
-        query = tasks_by_folder_paths_graphql_query(fields)
-        for attr, filter_value in graphql_filters.items():
-            query.set_variable_value(attr, filter_value)
-
-        output = {
-            folder_path: []
-            for folder_path in folder_paths
-        }
-        for parsed_data in query.continuous_query(self):
-            for folder in parsed_data["project"]["folders"]:
-                folder_path = folder["path"]
-                for task in folder["tasks"]:
-                    if active is not None and active is not task["active"]:
-                        continue
-
-                    self._convert_entity_data(task)
-
-                    if own_attributes:
-                        fill_own_attribs(task)
-                    output[folder_path].append(task)
         return output
 
     def get_tasks_by_folder_path(

--- a/ayon_api/_api_helpers/tasks.py
+++ b/ayon_api/_api_helpers/tasks.py
@@ -9,9 +9,7 @@ from ayon_api.utils import (
     create_entity_id,
     NOT_SET,
 )
-from ayon_api.graphql_queries import (
-    tasks_graphql_query,
-)
+from ayon_api.graphql_queries import tasks_graphql_query
 
 from .base import BaseServerAPI
 

--- a/ayon_api/_api_helpers/tasks.py
+++ b/ayon_api/_api_helpers/tasks.py
@@ -11,7 +11,6 @@ from ayon_api.utils import (
 )
 from ayon_api.graphql_queries import (
     tasks_graphql_query,
-    tasks_by_folder_paths_graphql_query,
 )
 
 from .base import BaseServerAPI

--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -243,56 +243,6 @@ def tasks_graphql_query(fields: set[str]) -> GraphQlQuery:
     return query
 
 
-def tasks_by_folder_paths_graphql_query(fields: set[str]) -> GraphQlQuery:
-    query = GraphQlQuery("TasksByFolderPathQuery")
-    project_name_var = query.add_variable("projectName", "String!")
-    task_names_var = query.add_variable("taskNames", "[String!]")
-    task_types_var = query.add_variable("taskTypes", "[String!]")
-    folder_paths_var = query.add_variable("folderPaths", "[String!]")
-    assignees_any_var = query.add_variable("taskAssigneesAny", "[String!]")
-    assignees_all_var = query.add_variable("taskAssigneesAll", "[String!]")
-    statuses_var = query.add_variable("taskStatuses", "[String!]")
-    tags_var = query.add_variable("taskTags", "[String!]")
-    filter_var = query.add_variable("filter", "String!")
-
-    project_field = query.add_field("project")
-    project_field.set_filter("name", project_name_var)
-
-    folders_field = project_field.add_field_with_edges("folders")
-    folders_field.add_field("path")
-    folders_field.set_filter("paths", folder_paths_var)
-
-    tasks_field = folders_field.add_field_with_edges("tasks")
-    # WARNING: At the moment when this been created 'names' filter
-    #   is not supported
-    tasks_field.set_filter("names", task_names_var)
-    tasks_field.set_filter("taskTypes", task_types_var)
-    tasks_field.set_filter("assigneesAny", assignees_any_var)
-    tasks_field.set_filter("assignees", assignees_all_var)
-    tasks_field.set_filter("statuses", statuses_var)
-    tasks_field.set_filter("tags", tags_var)
-    tasks_field.set_filter("filter", filter_var)
-
-    nested_fields = fields_to_dict(fields)
-
-    add_links_fields(tasks_field, nested_fields)
-
-    query_queue = collections.deque()
-    for key, value in nested_fields.items():
-        query_queue.append((key, value, tasks_field))
-
-    while query_queue:
-        item = query_queue.popleft()
-        key, value, parent = item
-        field = parent.add_field(key)
-        if value is FIELD_VALUE:
-            continue
-
-        for k, v in value.items():
-            query_queue.append((k, v, field))
-    return query
-
-
 def products_graphql_query(fields: set[str]) -> GraphQlQuery:
     query = GraphQlQuery("ProductsQuery")
 


### PR DESCRIPTION
## Changelog Description
Fetch folders first and then tasks instead of double nested edges.

## Additional review information
Change related to changes [in this PR](https://github.com/ynput/ayon-python-api/pull/329). In case multiple paths would be passed this approach is faster.

## Testing notes:
1. `get_tasks_by_folder_paths` still works
