### PR TITLE
Product Types: Remove 'icon' and 'color' from product type fields

### DIFF
--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -75,15 +75,14 @@ DEFAULT_PROJECT_LINK_TYPES_FIELDS = {
 # --- Product types ---
 DEFAULT_PRODUCT_TYPE_FIELDS = {
     "name",
-    "icon",
-    "color",
 }
 
 # --- Product base type ---
 DEFAULT_PRODUCT_BASE_TYPE_FIELDS = {
-    # Ignore 'icon' and 'color'
-    # - current server implementation always returns 'null'
+    # TODO add 'icon' and 'color' when server supports it
     "name",
+    # "icon",
+    # "color",
 }
 
 # --- Project ---


### PR DESCRIPTION
## Changelog Description
Remove `icon` and `color` fields from `project.productTypes`.

## Additional review information
The values of the field is always `None` and it should not be used anywhere anymore.

## Testing notes:
1. Receiving `productTypes` from project does return only `name`.
```python
project_name = "..."
project_entity = ayon_api.get_project(project_name, fields={"productTypes"})
```
