### PR TITLE
Project: Fix 'get_project' when using GraphQl

### DIFF
--- a/ayon_api/_api_helpers/projects.py
+++ b/ayon_api/_api_helpers/projects.py
@@ -364,6 +364,7 @@ class ProjectsAPI(BaseServerAPI):
             graphql_project = next(self._get_graphql_projects(
                 None,
                 None,
+                include_skeleton=True,
                 project_name=project_name,
                 fields=graphql_fields,
                 own_attributes=own_attributes,


### PR DESCRIPTION
## Changelog Description
Fix GraphQl fetching of project.

## Additional review information
Pass in `include_skeletal` when getting project using graphql in `get_project`.

## Testing notes:
1. Call `ayon_api.get_project("some_project", fields={"productTypes"})`
2. It should not fail.
