### PR TITLE
Public api: Fix positional arguments

### DIFF
--- a/automated_api.py
+++ b/automated_api.py
@@ -269,7 +269,10 @@ def sig_params_to_str(sig, param_names, api_globals, indent=0):
         func_params.append("/")
 
     for param_name, param in pos_or_kw:
-        body_params.append(f"{param_name}={param_name}")
+        body_par = param_name
+        if not var_positional:
+            body_par = f"{param_name}={param_name}"
+        body_params.append(body_par)
         func_params.append(_kw_default_to_str(param_name, param, api_globals))
 
     if var_positional:

--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -2982,8 +2982,8 @@ def get_addon_endpoint(
     """
     con = get_server_api_connection()
     return con.get_addon_endpoint(
-        addon_name=addon_name,
-        addon_version=addon_version,
+        addon_name,
+        addon_version,
         *subpaths,
     )
 
@@ -3032,8 +3032,8 @@ def get_addon_url(
     """
     con = get_server_api_connection()
     return con.get_addon_url(
-        addon_name=addon_name,
-        addon_version=addon_version,
+        addon_name,
+        addon_version,
         *subpaths,
         use_rest=use_rest,
     )


### PR DESCRIPTION
## Changelog Description
Fix positional arguments usage in public api.

## Additional review information
Fix `get_addon_endpoint` and `get_addon_url` by not using kwargs when passing arguments to the function.

## Testing notes:
1. It is possible to use `get_addon_endpoint` and `get_addon_url` from public api with subpaths.

```python
endpoint = ayon_api.get_addon_endpoint(
    "core",
    "1.9.7",
    "test",
)
print(endpoint)
```