### PR TITLE
Add wait for events argument to operations

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -1621,7 +1621,9 @@ def get_rest_entity_by_id(
 def send_batch_operations(
     project_name: str,
     operations: list[dict[str, Any]],
+    *,
     can_fail: bool = False,
+    wait_for_events: bool = False,
     raise_on_fail: bool = True,
 ) -> list[dict[str, Any]]:
     """Post multiple CRUD operations to server.
@@ -1636,6 +1638,8 @@ def send_batch_operations(
         operations (list[dict[str, Any]]): Operations to be processed.
         can_fail (bool): Server will try to process all
             operations even if one of them fails.
+        wait_for_events (bool): The operations are marked as done before
+            related events are triggered on server.
         raise_on_fail (bool): Raise exception if an operation
             fails. You can handle failed operations on your own
             when set to 'False'.
@@ -1654,6 +1658,7 @@ def send_batch_operations(
         project_name=project_name,
         operations=operations,
         can_fail=can_fail,
+        wait_for_events=wait_for_events,
         raise_on_fail=raise_on_fail,
     )
 
@@ -1663,8 +1668,9 @@ def send_background_batch_operations(
     operations: list[dict[str, Any]],
     *,
     can_fail: bool = False,
-    wait: bool = False,
+    wait_for_events: bool = False,
     raise_on_fail: bool = True,
+    wait: bool = False,
 ) -> BackgroundOperationTask:
     """Post multiple CRUD operations to server.
 
@@ -1687,10 +1693,12 @@ def send_background_batch_operations(
         operations (list[dict[str, Any]]): Operations to be processed.
         can_fail (bool): Server will try to process all
             operations even if one of them fails.
-        wait (bool): Wait for operations to end.
+        wait_for_events (bool): The operations are marked as done before
+            related events are triggered on server.
         raise_on_fail (bool): Raise exception if an operation
             fails. You can handle failed operations on your own
             when set to 'False'. Used when 'wait' is enabled.
+        wait (bool): Wait for operations to end.
 
     Raises:
         ValueError: Operations can't be converted to json string.
@@ -1706,8 +1714,9 @@ def send_background_batch_operations(
         project_name=project_name,
         operations=operations,
         can_fail=can_fail,
-        wait=wait,
+        wait_for_events=wait_for_events,
         raise_on_fail=raise_on_fail,
+        wait=wait,
     )
 
 
@@ -2709,7 +2718,9 @@ def set_entity_watchers(
 def send_activities_batch_operations(
     project_name: str,
     operations: list[dict[str, Any]],
+    *,
     can_fail: bool = False,
+    wait_for_events: bool = False,
     raise_on_fail: bool = True,
 ) -> list[dict[str, Any]]:
     """Post multiple CRUD activities operations to server.
@@ -2724,6 +2735,8 @@ def send_activities_batch_operations(
         operations (list[dict[str, Any]]): Operations to be processed.
         can_fail (Optional[bool]): Server will try to process all
             operations even if one of them fails.
+        wait_for_events (bool): The operations are marked as done before
+            related events are triggered on server.
         raise_on_fail (Optional[bool]): Raise exception if an operation
             fails. You can handle failed operations on your own
             when set to 'False'.
@@ -2742,6 +2755,7 @@ def send_activities_batch_operations(
         project_name=project_name,
         operations=operations,
         can_fail=can_fail,
+        wait_for_events=wait_for_events,
         raise_on_fail=raise_on_fail,
     )
 

--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -1638,8 +1638,7 @@ def send_batch_operations(
         operations (list[dict[str, Any]]): Operations to be processed.
         can_fail (bool): Server will try to process all
             operations even if one of them fails.
-        wait_for_events (bool): The operations are marked as done before
-            related events are triggered on server.
+        wait_for_events (bool): Wait for events to be processed on server.
         raise_on_fail (bool): Raise exception if an operation
             fails. You can handle failed operations on your own
             when set to 'False'.
@@ -1693,8 +1692,7 @@ def send_background_batch_operations(
         operations (list[dict[str, Any]]): Operations to be processed.
         can_fail (bool): Server will try to process all
             operations even if one of them fails.
-        wait_for_events (bool): The operations are marked as done before
-            related events are triggered on server.
+        wait_for_events (bool): Wait for events to be processed on server.
         raise_on_fail (bool): Raise exception if an operation
             fails. You can handle failed operations on your own
             when set to 'False'. Used when 'wait' is enabled.
@@ -2735,8 +2733,7 @@ def send_activities_batch_operations(
         operations (list[dict[str, Any]]): Operations to be processed.
         can_fail (Optional[bool]): Server will try to process all
             operations even if one of them fails.
-        wait_for_events (bool): The operations are marked as done before
-            related events are triggered on server.
+        wait_for_events (bool): Wait for events to be processed on server.
         raise_on_fail (Optional[bool]): Raise exception if an operation
             fails. You can handle failed operations on your own
             when set to 'False'.

--- a/ayon_api/_api_helpers/activities.py
+++ b/ayon_api/_api_helpers/activities.py
@@ -387,8 +387,7 @@ class ActivitiesAPI(BaseServerAPI):
             operations (list[dict[str, Any]]): Operations to be processed.
             can_fail (Optional[bool]): Server will try to process all
                 operations even if one of them fails.
-            wait_for_events (bool): The operations are marked as done before
-                related events are triggered on server.
+            wait_for_events (bool): Wait for events to be processed on server.
             raise_on_fail (Optional[bool]): Raise exception if an operation
                 fails. You can handle failed operations on your own
                 when set to 'False'.

--- a/ayon_api/_api_helpers/activities.py
+++ b/ayon_api/_api_helpers/activities.py
@@ -370,8 +370,10 @@ class ActivitiesAPI(BaseServerAPI):
         self,
         project_name: str,
         operations: list[dict[str, Any]],
+        *,
         can_fail: bool = False,
-        raise_on_fail: bool = True
+        wait_for_events: bool = False,
+        raise_on_fail: bool = True,
     ) -> list[dict[str, Any]]:
         """Post multiple CRUD activities operations to server.
 
@@ -385,6 +387,8 @@ class ActivitiesAPI(BaseServerAPI):
             operations (list[dict[str, Any]]): Operations to be processed.
             can_fail (Optional[bool]): Server will try to process all
                 operations even if one of them fails.
+            wait_for_events (bool): The operations are marked as done before
+                related events are triggered on server.
             raise_on_fail (Optional[bool]): Raise exception if an operation
                 fails. You can handle failed operations on your own
                 when set to 'False'.
@@ -401,6 +405,7 @@ class ActivitiesAPI(BaseServerAPI):
         return self._send_batch_operations(
             f"projects/{project_name}/operations/activities",
             operations,
-            can_fail,
-            raise_on_fail,
+            can_fail=can_fail,
+            wait_for_events=wait_for_events,
+            raise_on_fail=raise_on_fail,
         )

--- a/ayon_api/_api_helpers/base.py
+++ b/ayon_api/_api_helpers/base.py
@@ -167,6 +167,7 @@ class BaseServerAPI:
         uri: str,
         operations: list[dict[str, Any]],
         can_fail: bool,
+        wait_for_events: bool,
         raise_on_fail: bool
     ) -> list[dict[str, Any]]:
         raise NotImplementedError()

--- a/ayon_api/operations.py
+++ b/ayon_api/operations.py
@@ -827,7 +827,13 @@ class OperationsSession(object):
         ]
 
     def commit(self, *, wait_for_events: bool | None = None) -> None:
-        """Commit session operations."""
+        """Commit session operations.
+
+        Args:
+            wait_for_events (bool | None): Wait for events to be processed
+                on server. Use 'None' to use the default value defined on
+                OperationsSession object.
+        """
         operations, self._operations = self._operations, []
         if not operations:
             return

--- a/ayon_api/operations.py
+++ b/ayon_api/operations.py
@@ -741,12 +741,21 @@ class OperationsSession(object):
     Args:
         con (Optional[ServerAPI]): Connection to server. Global connection
             is used if not passed.
+        wait_for_events (bool): Wait for events to be processed on server.
+            Default value of the argument. Can be changed when 'commit'
+            is called.
 
     """
-    def __init__(self, con: Optional[ServerAPI] = None) -> None:
+    def __init__(
+        self,
+        con: Optional[ServerAPI] = None,
+        *,
+        wait_for_events: bool = False,
+    ) -> None:
         if con is None:
             con = get_server_api_connection()
         self._con = con
+        self._wait_for_events = wait_for_events
         self._project_cache = {}
         self._operations = []
         self._nested_operations = collections.defaultdict(list)
@@ -817,7 +826,7 @@ class OperationsSession(object):
             for operation in self._operations
         ]
 
-    def commit(self) -> None:
+    def commit(self, *, wait_for_events: bool | None = None) -> None:
         """Commit session operations."""
         operations, self._operations = self._operations, []
         if not operations:
@@ -827,6 +836,9 @@ class OperationsSession(object):
         for operation in operations:
             operations_by_project[operation.project_name].append(operation)
 
+        if wait_for_events is None:
+            wait_for_events = self._wait_for_events
+
         for project_name, operations in operations_by_project.items():
             operations_body = []
             for operation in operations:
@@ -835,7 +847,11 @@ class OperationsSession(object):
                     operations_body.append(body)
 
             self._con.send_background_batch_operations(
-                project_name, operations_body, wait=True, can_fail=False
+                project_name,
+                operations_body,
+                can_fail=False,
+                wait_for_events=wait_for_events,
+                wait=True,
             )
 
     def create_entity(

--- a/ayon_api/operations.py
+++ b/ayon_api/operations.py
@@ -833,6 +833,7 @@ class OperationsSession(object):
             wait_for_events (bool | None): Wait for events to be processed
                 on server. Use 'None' to use the default value defined on
                 OperationsSession object.
+
         """
         operations, self._operations = self._operations, []
         if not operations:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2475,7 +2475,9 @@ class ServerAPI(
         self,
         project_name: str,
         operations: list[dict[str, Any]],
+        *,
         can_fail: bool = False,
+        wait_for_events: bool = False,
         raise_on_fail: bool = True,
     ) -> list[dict[str, Any]]:
         """Post multiple CRUD operations to server.
@@ -2490,6 +2492,8 @@ class ServerAPI(
             operations (list[dict[str, Any]]): Operations to be processed.
             can_fail (bool): Server will try to process all
                 operations even if one of them fails.
+            wait_for_events (bool): The operations are marked as done before
+                related events are triggered on server.
             raise_on_fail (bool): Raise exception if an operation
                 fails. You can handle failed operations on your own
                 when set to 'False'.
@@ -2506,8 +2510,9 @@ class ServerAPI(
         return self._send_batch_operations(
             f"projects/{project_name}/operations",
             operations,
-            can_fail,
-            raise_on_fail,
+            can_fail=can_fail,
+            wait_for_events=wait_for_events,
+            raise_on_fail=raise_on_fail,
         )
 
     def send_background_batch_operations(
@@ -2516,8 +2521,9 @@ class ServerAPI(
         operations: list[dict[str, Any]],
         *,
         can_fail: bool = False,
-        wait: bool = False,
+        wait_for_events: bool = False,
         raise_on_fail: bool = True,
+        wait: bool = False,
     ) -> BackgroundOperationTask:
         """Post multiple CRUD operations to server.
 
@@ -2540,10 +2546,12 @@ class ServerAPI(
             operations (list[dict[str, Any]]): Operations to be processed.
             can_fail (bool): Server will try to process all
                 operations even if one of them fails.
-            wait (bool): Wait for operations to end.
+            wait_for_events (bool): The operations are marked as done before
+                related events are triggered on server.
             raise_on_fail (bool): Raise exception if an operation
                 fails. You can handle failed operations on your own
                 when set to 'False'. Used when 'wait' is enabled.
+            wait (bool): Wait for operations to end.
 
         Raises:
             ValueError: Operations can't be converted to json string.
@@ -2558,7 +2566,8 @@ class ServerAPI(
         response = self.post(
             f"projects/{project_name}/operations/background",
             operations=operations_body,
-            canFail=can_fail
+            canFail=can_fail,
+            waitForEvents=wait_for_events,
         )
         response.raise_for_status()
         if not wait:
@@ -2631,7 +2640,8 @@ class ServerAPI(
         uri: str,
         operations: list[dict[str, Any]],
         can_fail: bool,
-        raise_on_fail: bool
+        wait_for_events: bool,
+        raise_on_fail: bool,
     ) -> list[dict[str, Any]]:
         if not operations:
             return []
@@ -2643,7 +2653,8 @@ class ServerAPI(
         response = self.post(
             uri,
             operations=operations_body,
-            canFail=can_fail
+            canFail=can_fail,
+            waitForEvents=wait_for_events,
         )
 
         op_results = response.get("operations")

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2492,8 +2492,7 @@ class ServerAPI(
             operations (list[dict[str, Any]]): Operations to be processed.
             can_fail (bool): Server will try to process all
                 operations even if one of them fails.
-            wait_for_events (bool): The operations are marked as done before
-                related events are triggered on server.
+            wait_for_events (bool): Wait for events to be processed on server.
             raise_on_fail (bool): Raise exception if an operation
                 fails. You can handle failed operations on your own
                 when set to 'False'.
@@ -2546,8 +2545,7 @@ class ServerAPI(
             operations (list[dict[str, Any]]): Operations to be processed.
             can_fail (bool): Server will try to process all
                 operations even if one of them fails.
-            wait_for_events (bool): The operations are marked as done before
-                related events are triggered on server.
+            wait_for_events (bool): Wait for events to be processed on server.
             raise_on_fail (bool): Raise exception if an operation
                 fails. You can handle failed operations on your own
                 when set to 'False'. Used when 'wait' is enabled.


### PR DESCRIPTION
## Changelog Description
Operations do define `wait_for_events` argument to be defined.

## Additional review information
The option is available for a very long time, it was added before `raise_on_fail` so it does not require any additional validations (`1.10.3`). By default it is set to `False` which seems to be matching the server default.

## Testing notes:
1. Validate code changes.

Resolves https://github.com/ynput/ayon-python-api/issues/345
